### PR TITLE
Remember to have cgo enabled

### DIFF
--- a/content/gettingstarted/mac.md
+++ b/content/gettingstarted/mac.md
@@ -24,6 +24,7 @@ Ensure that you follow the official [Go installation instructions](https://golan
  * Check Go is installed corectly: `go version`
  * Check "~/go/bin" is in your PATH variable: `echo $PATH | grep go/bin`
  * Check "GO111MODULE" environment variable is set to "on": `echo ${GO111MODULE}`
+ * Check "CGO_ENABLED" environment variable is set to "1": `echo ${CGO_ENABLED}`
 
 ### npm
 


### PR DESCRIPTION
I had trouble making wail build my app by constantly getting the error :
```
github.com/wailsapp/wails/lib/renderer/webview: build constraints exclude all Go files
```

After re-reading the Mac documentation, I spotted the sentence:
```
Wails uses cgo to bind to...
```

Adding the `CGO_ENABLED=1` to the environment made it work.

So let's add an explicit verification of this flag !